### PR TITLE
add link to rubydoc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ myPrinters = client.printers
 
 ##Docs
 
-a Ruby *yardoc* is included in PrintNode-Ruby/doc/
+a Ruby *yardoc* is included in PrintNode-Ruby/doc/ and are also available [online.](http://www.rubydoc.info/github/PrintNode/PrintNode-Ruby)


### PR DESCRIPTION
http://www.rubydoc.info/ is a free/automatic docs generation hosting service for YARD. It's an easy way to view the docs. 