### PR TITLE
Assumptions about base64

### DIFF
--- a/lib/printnode/client.rb
+++ b/lib/printnode/client.rb
@@ -2,7 +2,6 @@ require 'net/https'
 require 'uri'
 require 'json'
 require 'ostruct'
-require 'base64'
 require 'cgi'
 
 module PrintNode

--- a/lib/printnode/printjob.rb
+++ b/lib/printnode/printjob.rb
@@ -1,4 +1,3 @@
-require 'base64'
 module PrintNode
   # An object for printjob creation.
   # @author Jake Torrance
@@ -16,11 +15,7 @@ module PrintNode
       hash['printerId'] = @printer_id
       hash['title'] = @title
       hash['contentType'] = @content_type
-      if @content_type.match('base64$')
-        hash ['content'] = Base64.encode64(IO.read(@content))
-      else
-        hash ['content'] = @content
-      end
+      hash['content'] = @content
       hash['source'] = @source
       hash
     end


### PR DESCRIPTION
I have ZPL strings being dynamically generated by my application, they're not written out to disk at all and they're not available via HTTP without authentication.

https://github.com/PrintNode/PrintNode-Ruby/blob/master/lib/printnode/printjob.rb#L19-L23

Makes two pretty big assumptions about `base64` encoded files:

1. They're something that can be `IO.read()`, e.g. on disk.
2. Undocumented automatic base64 encoding.

My assumption of the method before reading the code would be that it'd take whatever arbitrary content that I fed it, and the remote API would succeed or fail if it wasn't correctly formatted.

I propose simplifying to just `hash['content'] = @content` and leave it up to the user to `IO.read` or not, base64 encode or whatever else to get the format of the `content` object to match the `content_type` specified.
 
