### PR TITLE
Add ability to pass base64 encoded string directly to print job

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,3 +2,4 @@
 1.0.1 -> 1.0.3 major changes that are incorrectly versioned.
 1.0.4 Reverting changes from 1.0.1 -> 1.0.3
 1.0.5 Fix for base64 encoded PrintJobs - now correctly encodes the printjob.
+1.0.6 Allow passing a base64 encoded string to a printjob instead of a file path

--- a/lib/printnode/client.rb
+++ b/lib/printnode/client.rb
@@ -2,7 +2,6 @@ require 'net/https'
 require 'uri'
 require 'json'
 require 'ostruct'
-require 'base64'
 require 'cgi'
 
 module PrintNode
@@ -10,6 +9,8 @@ module PrintNode
   # @author Jake Torrance
   # @author PrintNode
   class Client
+
+    attr_reader :headers
 
     # If an argument is not a string, map it to a string so it can be escaped
     # and put into a URL.
@@ -23,7 +24,6 @@ module PrintNode
       CGI.escape(obj)
     end
 
-    attr_reader :headers
     # Initializes auth object, api url and headers.
     #
     # @param auth [PrintNode::Auth] auth object with credentials.

--- a/lib/printnode/printjob.rb
+++ b/lib/printnode/printjob.rb
@@ -1,4 +1,5 @@
 require 'base64'
+
 module PrintNode
   # An object for printjob creation.
   # @author Jake Torrance
@@ -10,21 +11,6 @@ module PrintNode
     attr_accessor :content
     attr_accessor :source
 
-    # Maps the object into a hash ready for JSON Encoding.
-    def to_hash
-      hash = {}
-      hash['printerId'] = @printer_id
-      hash['title'] = @title
-      hash['contentType'] = @content_type
-      if @content_type.match('base64$')
-        hash ['content'] = Base64.encode64(IO.read(@content))
-      else
-        hash ['content'] = @content
-      end
-      hash['source'] = @source
-      hash
-    end
-
     # Initializes the object with the variables required.
     def initialize(printer_id, title, content_type, content, source)
       @printer_id = printer_id
@@ -32,6 +18,24 @@ module PrintNode
       @content_type = content_type
       @content = content
       @source = source
+    end
+
+    # Maps the object into a hash ready for JSON Encoding.
+    def to_hash
+      hash = {}
+      hash['printerId'] = @printer_id
+      hash['title'] = @title
+      hash['contentType'] = @content_type
+      # Used to be, we only supported file names for Base64, but it's actually better
+      # to allow the user to send us a data string if they desire.  Testing the
+      # content to see if it's a path allows for backwards compatibility
+      if @content_type.match('base64$') && File.exist?(@content)
+        hash ['content'] = Base64.encode64(IO.read(@content))
+      else
+        hash ['content'] = @content
+      end
+      hash['source'] = @source
+      hash
     end
   end
 end

--- a/printnode.gemspec
+++ b/printnode.gemspec
@@ -1,16 +1,16 @@
 Gem::Specification.new do |s|
 	s.name 					= "printnode"
-    s.version				= "1.0.5"
+  s.version				= "1.0.6"
 	s.date					= "2015-08-19"
 	s.summary				= "PrintNode-Ruby"
-	s.description			= "Ruby API Library for PrintNode remote printing service."
-	s.authors 				= ["PrintNode","Jake Torrance"]
+	s.description		= "Ruby API Library for PrintNode remote printing service."
+	s.authors 			= ["PrintNode","Jake Torrance"]
 	s.email					= ["support@printnode.com"]
-    s.files					= ["lib/printnode.rb","lib/printnode/client.rb","lib/printnode/api_exception.rb","lib/printnode/auth.rb","lib/printnode/account.rb","lib/printnode/printjob.rb"]
-	s.homepage				= "https://www.printnode.com"
+  s.files					= ["lib/printnode.rb","lib/printnode/client.rb","lib/printnode/api_exception.rb","lib/printnode/auth.rb","lib/printnode/account.rb","lib/printnode/printjob.rb"]
+	s.homepage			= "https://www.printnode.com"
 	s.license				= "MIT"
   s.required_ruby_version = '>=1.9'
 	s.post_install_message 	= "Happy Printing!"
-    s.add_development_dependency 'json', '>=0'
-    s.add_development_dependency 'test-unit', '>=0'
+  s.add_development_dependency 'json', '>=0'
+  s.add_development_dependency 'test-unit', '>=0'
 end

--- a/printnode.gemspec
+++ b/printnode.gemspec
@@ -1,16 +1,16 @@
 Gem::Specification.new do |s|
-	s.name 					= "printnode"
-  s.version				= "1.0.6"
-	s.date					= "2015-08-19"
-	s.summary				= "PrintNode-Ruby"
-	s.description		= "Ruby API Library for PrintNode remote printing service."
-	s.authors 			= ["PrintNode","Jake Torrance"]
-	s.email					= ["support@printnode.com"]
-  s.files					= ["lib/printnode.rb","lib/printnode/client.rb","lib/printnode/api_exception.rb","lib/printnode/auth.rb","lib/printnode/account.rb","lib/printnode/printjob.rb"]
-	s.homepage			= "https://www.printnode.com"
-	s.license				= "MIT"
+  s.name          = "printnode"
+  s.version       = "1.0.6"
+  s.date          = "2015-08-19"
+  s.summary       = "PrintNode-Ruby"
+  s.description   = "Ruby API Library for PrintNode remote printing service."
+  s.authors       = ["PrintNode","Jake Torrance"]
+  s.email         = ["support@printnode.com"]
+  s.files         = ["lib/printnode.rb","lib/printnode/client.rb","lib/printnode/api_exception.rb","lib/printnode/auth.rb","lib/printnode/account.rb","lib/printnode/printjob.rb"]
+  s.homepage      = "https://www.printnode.com"
+  s.license       = "MIT"
   s.required_ruby_version = '>=1.9'
-	s.post_install_message 	= "Happy Printing!"
+  s.post_install_message  = "Happy Printing!"
   s.add_development_dependency 'json', '>=0'
   s.add_development_dependency 'test-unit', '>=0'
 end


### PR DESCRIPTION
Provides backwards compatibility by testing for a valid file path and reverting to old read + encode method of content handling.  Also bumped version and updated the changelog.