### PR TITLE
fix use_ssl check for api_url

### DIFF
--- a/lib/printnode/client.rb
+++ b/lib/printnode/client.rb
@@ -100,7 +100,7 @@ module PrintNode
     def start_response(request, uri)
       response = Net::HTTP.start(uri.hostname,
                                  uri.port,
-                                 use_ssl: uri.scheme = 'https') do |http|
+                                 use_ssl: uri.scheme == 'https') do |http|
         http.request(request)
       end
       http_error_handler(response)


### PR DESCRIPTION
The current behaviour here _sets_ `uri.scheme` to `https` regardless of what it is.

The intent of the line is to set `use_ssl` to `true` or `false` depending on the value of `uri.scheme`.

This PR fixes this.

This means that the api_url can be set to http scheme urls.
My use case for this is stubbing PrintNode in testing and development by changing the api_url.