### PR TITLE
Update create_printjob to handle passing in printer options

### DIFF
--- a/lib/printnode/client.rb
+++ b/lib/printnode/client.rb
@@ -439,11 +439,7 @@ module PrintNode
     # @see https://www.printnode.com/docs/api/curl#printjob-options PrintJob options on API Docs
     def create_printjob(printjob, options = {})
       hash = printjob.to_hash
-      if options
-        options.each do |(k, v)|
-          hash[k] = v
-        end
-      end
+      hash["options"] = options if options
       JSON.parse('[' + post('/printjobs/', hash).body + ']')[0]
     end
 


### PR DESCRIPTION
Had an issue with printer options not being picked up, found that in the current code the printer options are just being added to the hash instead of to options. This should allow for passing in printer options now on the create_printjob method. 